### PR TITLE
Replace deprecated android.support.annotations with androidx.annotati…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,8 +36,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:support-annotations:28.0.0'
-
-    //implementation 'haibison.android:underdogs:4.+'
+    implementation 'androidx.annotation:annotation:1.6.0'
 }//dependencies
 

--- a/app/src/main/java/haibison/android/lockpattern/Alp.java
+++ b/app/src/main/java/haibison/android/lockpattern/Alp.java
@@ -19,7 +19,7 @@ package haibison.android.lockpattern;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Some constants about the library.

--- a/app/src/main/java/haibison/android/lockpattern/LockPatternActivity.java
+++ b/app/src/main/java/haibison/android/lockpattern/LockPatternActivity.java
@@ -33,10 +33,6 @@ import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 import android.provider.Settings;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.RequiresApi;
-import android.support.annotation.StringRes;
-import android.support.annotation.StyleRes;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -46,6 +42,11 @@ import android.view.ViewConfiguration;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.Button;
 import android.widget.TextView;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.RequiresApi;
+import androidx.annotation.StringRes;
+import androidx.annotation.StyleRes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,8 +64,9 @@ import haibison.android.lockpattern.widget.LockPatternUtils;
 import haibison.android.lockpattern.widget.LockPatternView;
 import haibison.android.lockpattern.widget.LockPatternView.Cell;
 import haibison.android.lockpattern.widget.LockPatternView.DisplayMode;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static android.text.format.DateUtils.SECOND_IN_MILLIS;
 

--- a/app/src/main/java/haibison/android/lockpattern/collect/Lists.java
+++ b/app/src/main/java/haibison/android/lockpattern/collect/Lists.java
@@ -16,7 +16,7 @@
 
 package haibison.android.lockpattern.collect;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/haibison/android/lockpattern/utils/AlpSettings.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/AlpSettings.java
@@ -26,8 +26,9 @@ import android.preference.PreferenceManager;
 
 import haibison.android.lockpattern.Alp;
 import haibison.android.lockpattern.R;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * All settings for the library. They are stored in {@link SharedPreferences}.

--- a/app/src/main/java/haibison/android/lockpattern/utils/Encrypter.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/Encrypter.java
@@ -21,7 +21,8 @@ import android.content.Context;
 import java.util.List;
 
 import haibison.android.lockpattern.widget.LockPatternView.Cell;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 /**
  * Interface for encrypter.

--- a/app/src/main/java/haibison/android/lockpattern/utils/FloatAnimator.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/FloatAnimator.java
@@ -21,8 +21,9 @@ import android.os.Handler;
 import java.util.List;
 
 import haibison.android.lockpattern.collect.Lists;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Float animator.

--- a/app/src/main/java/haibison/android/lockpattern/utils/LoadingView.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/LoadingView.java
@@ -19,11 +19,12 @@ package haibison.android.lockpattern.utils;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Handler;
-import android.support.annotation.CallSuper;
 import android.view.View;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.CallSuper;
+
 
 import static android.text.format.DateUtils.SECOND_IN_MILLIS;
 

--- a/app/src/main/java/haibison/android/lockpattern/utils/Randoms.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/Randoms.java
@@ -20,7 +20,8 @@ import java.util.List;
 import java.util.Random;
 
 import haibison.android.lockpattern.collect.Lists;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 /**
  * Random utilities.

--- a/app/src/main/java/haibison/android/lockpattern/utils/ResUtils.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/ResUtils.java
@@ -19,10 +19,10 @@ package haibison.android.lockpattern.utils;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.Resources.Theme;
-import android.support.annotation.AttrRes;
 import android.util.TypedValue;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
 
 /**
  * Resources' utilities.

--- a/app/src/main/java/haibison/android/lockpattern/utils/SimpleWeakEncryption.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/SimpleWeakEncryption.java
@@ -37,8 +37,8 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * The <strong>simple-and-weak</strong> encryption utilities.

--- a/app/src/main/java/haibison/android/lockpattern/utils/UI.java
+++ b/app/src/main/java/haibison/android/lockpattern/utils/UI.java
@@ -23,7 +23,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Window;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import static haibison.android.lockpattern.Alp.TAG;
 import static haibison.android.lockpattern.BuildConfig.DEBUG;

--- a/app/src/main/java/haibison/android/lockpattern/widget/LockPatternUtils.java
+++ b/app/src/main/java/haibison/android/lockpattern/widget/LockPatternUtils.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 
 import haibison.android.lockpattern.collect.Lists;
 import haibison.android.lockpattern.utils.Randoms;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import static haibison.android.lockpattern.Alp.TAG;
 import static haibison.android.lockpattern.BuildConfig.DEBUG;

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true


### PR DESCRIPTION
…ons.

This will allow afwall to also move to androidx eventually.